### PR TITLE
Fixed super cryptic discord error 'embeds=[0]'. turns out it was just…

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,11 +1,11 @@
 module.exports = {
 	server: {
-		port: 8080
+		port: process.env.PORT || 8080
 	},
 	webhooks: {
-		'my-super-awesome-hook': 'https://canary.discordapp.com/api/webhooks/123456789123456789/aaaBBB'
+		[process.env.WEBHOOK_NAME || "my-super-awesome-hook"]: process.env.WEBHOOK_URL || "https://canary.discordapp.com/api/webhooks/123456789123456789/aaaBBB"
 	},
 	authentication: {
-		secret: 'change_me'
+		secret: process.env.WEBHOOK_SECRET || "change_me"
 	}
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "unirest": "^0.5.1",
+    "valid-url": "^1.0.9",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/src/events/push.js
+++ b/src/events/push.js
@@ -2,6 +2,7 @@ const util = require('util');
 
 const git = require('../git');
 const discord = require('../discord');
+const validUrl = require('valid-url');
 
 class Formatter {
 	format(body) {
@@ -15,7 +16,14 @@ class Formatter {
 			embed.url = git.getCommitDiffURL(body.project.web_url, body.before, body.after);
 
 			embed.color = 0x00bcd4;
-			embed.author = discord.create_author_obj(body.user_name, body.user_avatar);
+
+			let avatar_url = body.user_avatar;
+			//Check to see if this is a GitLab avatar
+			if(!validUrl.isWebUri(avatar_url)) {
+				avatar_url = `https://gitlab.com${avatar_url}`;
+			}
+
+			embed.author = discord.create_author_obj(body.user_name, avatar_url);
 
 			embed.fields = [];
 


### PR DESCRIPTION
… a avatar url issue where if it was gitlabs avatar url it wasn't a proper url and just a path for gitlab to retrieve it. Also added some stuff for heroku users in the config.example.js for easy setup